### PR TITLE
Configuring codecov.io to ignore tests folder and src/Aux

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+ignore:
+  - "lib"
+  - "tests"
+  - "src/Aux"
+


### PR DESCRIPTION
Added .codecov.yml file to configure codecov.io to ignore certain files.